### PR TITLE
Added close option to allow set tree to folded up

### DIFF
--- a/jsontree.js
+++ b/jsontree.js
@@ -58,9 +58,15 @@
     _render([j], self.find('.jsontree'));
   };
 
-  $.fn.jsontree = function (option) {
+  $.fn.jsontree = function (option, close) {
     return this.each(function () {
       var self = $(this), data = self.data('jsontree');
+      
+      if (close == null)
+      {
+        close = false;
+      }
+      
       if (!data) {
         if (typeof option == 'string') {
           data = option;
@@ -70,7 +76,13 @@
           self.data('jsontree', '');
         }
       }
+      
       new JsonTree(self);
+      if (close)
+      {
+        $('.jsontree .fold', self).eq(0).trigger('click');
+      }
+      
     });
   };
 


### PR DESCRIPTION
By adding an optional close parameter (which defaults to false) the user can now specify whether the tree is folded up when it's created.
